### PR TITLE
feat: add the grpc-plugins docker image

### DIFF
--- a/.github/workflows/docker-grpc-plugins.yml
+++ b/.github/workflows/docker-grpc-plugins.yml
@@ -1,0 +1,23 @@
+name: Docker / grpc-plugins
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'grpc-plugins/version.json'
+  pull_request:
+    paths:
+      - 'grpc-plugins/**'
+      - '.github/workflows/docker-grpc-plugins.yml'
+
+jobs:
+  build_docker_image:
+    uses: vegaprotocol/docker-public/.github/workflows/docker-generic.yml@main
+    with:
+      image_name: grpc-plugins
+      docker_context_path: ./grpc-plugins
+      platforms: linux/amd64, linux/arm64
+    secrets:
+      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/grpc-plugins/Dockerfile
+++ b/grpc-plugins/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:20.04 AS grpc_plugins
+ARG GRPC_VER=1.41.0
+
+
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends \
+	autoconf \
+	build-essential \
+	ca-certificates \
+	cmake \
+	git \
+	libtool \
+	pkg-config
+RUN git clone -b "v$GRPC_VER" https://github.com/grpc/grpc
+WORKDIR /grpc
+RUN git submodule update --init
+WORKDIR /grpc/cmake/build
+RUN cmake ../..
+RUN make -j "$(grep -c ^processor /proc/cpuinfo)"
+RUN make install
+RUN strip /usr/local/bin/protoc-* /usr/local/bin/grpc_*_plugin
+
+
+
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV BUF_VER="1.0.0-rc12"
+
+ARG UNAME=testuser
+ARG UID=1000
+ARG GID=1000
+
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+RUN chmod 1777 /tmp
+
+RUN apt update \
+	&& apt install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+        wget \
+		git \
+		jq \
+		make \
+		openssh-client \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+COPY --from=grpc_plugins /usr/local/bin/protoc* /usr/local/bin/
+COPY --from=grpc_plugins /usr/local/bin/grpc_python_plugin /usr/local/bin/
+
+RUN wget -q -O /usr/local/bin/buf https://github.com/bufbuild/buf/releases/download/v$BUF_VER/buf-Linux-$(uname -m) \
+	&& chmod 0755 /usr/local/bin/buf
+
+WORKDIR /workspace
+

--- a/grpc-plugins/README.md
+++ b/grpc-plugins/README.md
@@ -1,0 +1,5 @@
+# GRPC-plugins
+
+The GRPC-plugins docker image contains the helpers used to build and play with the proto buffers of The Vega Protocol. It is delivered as a docker image to minimize the time and work needed to build tools on the host machine.
+
+This docker image is used to compile the Python proto buffers for the system-tests

--- a/grpc-plugins/version.json
+++ b/grpc-plugins/version.json
@@ -1,0 +1,4 @@
+{
+    "version": "v1.41.0",
+    "name": "vegaprotocol/grpc-plugins"
+}


### PR DESCRIPTION
This is required to remove docker for system tests. This image will be used to make qa-guys life easier