### PR TITLE
chore: add vegacapsule, nomad and vega binaries to github-runner docker image

### DIFF
--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -55,7 +55,7 @@ ENV GOBIN=$HOME/go/bin \
     PATH=$PATH:$HOME/go/bin
 RUN mkdir -p $GOBIN \
     && mkdir -p ~/.vegacapsule \
-    && cp /usr/local/bin/nomad ~/.vegacapsule/nomad_${NOMAD_VERSION}
+    && ln -s /usr/local/bin/nomad ~/.vegacapsule/nomad_${NOMAD_VERSION}
 
 RUN vegacapsule version \
     && vega version \

--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -1,5 +1,8 @@
 FROM summerwind/actions-runner:v2.299.1-ubuntu-20.04
 USER root
+ENV VEGA_VERSION=v0.63.1
+ENV VEGACAPSULE_VERSION=v0.3.0
+ENV NOMAD_VERSION=1.3.1
 RUN curl -s https://deb.nodesource.com/setup_16.x | bash \
     && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
@@ -26,7 +29,28 @@ RUN curl -s https://deb.nodesource.com/setup_16.x | bash \
     && apt-get -f -y install ./google-chrome-stable_current_amd64.deb \
     && rm google-chrome-stable_current_amd64.deb \
     && rm -rf /var/lib/apt/lists/* 
+
+# Install vegacapsule
+RUN wget -q https://github.com/vegaprotocol/vegacapsule/releases/download/$VEGACAPSULE_VERSION/vegacapsule-linux-amd64.zip \
+    && unzip vegacapsule-linux-amd64.zip \
+    && mv vegacapsule /usr/local/bin/ \
+    && rm vegacapsule-linux-amd64.zip
+
+# Install Nomad
+RUN wget -q https://releases.hashicorp.com/nomad/#NOMAD_VERSION/nomad_#NOMAD_VERSION_darwin_amd64.zip \
+    && unzip nomad_#NOMAD_VERSION_darwin_amd64.zip \
+    && mv nomad /usr/local/bin/ \
+    && rm nomad_#NOMAD_VERSION_darwin_amd64.zip
+
+# Install Vega CLI
+RUN wget https://github.com/vegaprotocol/vega/releases/download/$VEGA_VERSION/vega-linux-amd64.zip \
+    && unzip vega-linux-amd64.zip \
+    && mv vega /usr/local/bin/ \
+    && rm vega-linux-amd64.zip 
+
 USER runner
 ENV GOBIN=$HOME/go/bin \
     PATH=$PATH:$HOME/go/bin
-RUN mkdir -p $GOBIN
+RUN mkdir -p $GOBIN \
+    && mkdir -p ~/.vegacapsule \
+    && cp /usr/local/bin/nomad ~/.vegacapsule/nomad_#NOMAD_VERSION

--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -37,10 +37,10 @@ RUN wget -q https://github.com/vegaprotocol/vegacapsule/releases/download/$VEGAC
     && rm vegacapsule-linux-amd64.zip
 
 # Install Nomad
-RUN wget -q https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_$NOMAD_VERSION_darwin_amd64.zip \
-    && unzip nomad_$NOMAD_VERSION_darwin_amd64.zip \
+RUN wget -q https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
+    && unzip nomad_${NOMAD_VERSION}_linux_amd64.zip \
     && mv nomad /usr/local/bin/ \
-    && rm nomad_$NOMAD_VERSION_darwin_amd64.zip
+    && rm nomad_${NOMAD_VERSION}_linux_amd64.zip
 
 # Install Vega CLI
 RUN wget https://github.com/vegaprotocol/vega/releases/download/$VEGA_VERSION/vega-linux-amd64.zip \
@@ -48,9 +48,15 @@ RUN wget https://github.com/vegaprotocol/vega/releases/download/$VEGA_VERSION/ve
     && mv vega /usr/local/bin/ \
     && rm vega-linux-amd64.zip 
 
+RUN chmod +x /usr/local/bin/vega /usr/local/bin/vegacapsule /usr/local/bin/nomad
+
 USER runner
 ENV GOBIN=$HOME/go/bin \
     PATH=$PATH:$HOME/go/bin
 RUN mkdir -p $GOBIN \
     && mkdir -p ~/.vegacapsule \
-    && cp /usr/local/bin/nomad ~/.vegacapsule/nomad_$NOMAD_VERSION
+    && cp /usr/local/bin/nomad ~/.vegacapsule/nomad_${NOMAD_VERSION}
+
+RUN vegacapsule version \
+    && vega version \
+    && nomad version

--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -37,10 +37,10 @@ RUN wget -q https://github.com/vegaprotocol/vegacapsule/releases/download/$VEGAC
     && rm vegacapsule-linux-amd64.zip
 
 # Install Nomad
-RUN wget -q https://releases.hashicorp.com/nomad/#NOMAD_VERSION/nomad_#NOMAD_VERSION_darwin_amd64.zip \
-    && unzip nomad_#NOMAD_VERSION_darwin_amd64.zip \
+RUN wget -q https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_$NOMAD_VERSION_darwin_amd64.zip \
+    && unzip nomad_$NOMAD_VERSION_darwin_amd64.zip \
     && mv nomad /usr/local/bin/ \
-    && rm nomad_#NOMAD_VERSION_darwin_amd64.zip
+    && rm nomad_$NOMAD_VERSION_darwin_amd64.zip
 
 # Install Vega CLI
 RUN wget https://github.com/vegaprotocol/vega/releases/download/$VEGA_VERSION/vega-linux-amd64.zip \
@@ -53,4 +53,4 @@ ENV GOBIN=$HOME/go/bin \
     PATH=$PATH:$HOME/go/bin
 RUN mkdir -p $GOBIN \
     && mkdir -p ~/.vegacapsule \
-    && cp /usr/local/bin/nomad ~/.vegacapsule/nomad_#NOMAD_VERSION
+    && cp /usr/local/bin/nomad ~/.vegacapsule/nomad_$NOMAD_VERSION

--- a/github-runner/version.json
+++ b/github-runner/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "v2.299.1-ubuntu-20.04-8",
+    "version": "v2.299.1-ubuntu-20.04-vega-v0.63.1-1",
     "name": "vegaprotocol/github-runner"
 }


### PR DESCRIPTION
chore: add vegacapsule, nomad and vega binaries to github-runner docker image