### PR TITLE
chore: update vega and capsule versions

### DIFF
--- a/.github/workflows/docker-github-runner.yml
+++ b/.github/workflows/docker-github-runner.yml
@@ -18,6 +18,7 @@ jobs:
       image_name: github-runner
       docker_context_path: ./github-runner
       platforms: linux/amd64
+      pre_pull_image: vegaprotocol/github-runner:latest
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-github-runner.yml
+++ b/.github/workflows/docker-github-runner.yml
@@ -18,7 +18,6 @@ jobs:
       image_name: github-runner
       docker_context_path: ./github-runner
       platforms: linux/amd64
-      pre_pull_image: vegaprotocol/github-runner:latest
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -29,8 +29,8 @@ RUN curl -s https://deb.nodesource.com/setup_16.x | bash \
     && rm -rf /var/lib/apt/lists/* 
 
 # ENV variables are here to allow cache previous step and speet the build up
-ENV VEGA_VERSION=v0.64.0
-ENV VEGACAPSULE_VERSION=v0.3.0
+ENV VEGA_VERSION=v0.65.1
+ENV VEGACAPSULE_VERSION=0.5.0
 ENV NOMAD_VERSION=1.3.1
 
 # Install vegacapsule

--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -s https://deb.nodesource.com/setup_16.x | bash \
 
 # ENV variables are here to allow cache previous step and speet the build up
 ENV VEGA_VERSION=v0.65.1
-ENV VEGACAPSULE_VERSION=0.5.0
+ENV VEGACAPSULE_VERSION=v0.5.0
 ENV NOMAD_VERSION=1.3.1
 
 # Install vegacapsule

--- a/github-runner/version.json
+++ b/github-runner/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "v2.299.1-ubuntu-20.04-vega-v0.64.0-1",
+    "version": "v2.299.1-ubuntu-20.04-vega-v0.65.1-1",
     "name": "vegaprotocol/github-runner"
 }


### PR DESCRIPTION
Update FE runners to use lates vega and vega capsule versions

closes [#2531](https://github.com/vegaprotocol/frontend-monorepo/pull/2498/files)