### PR TITLE
chore: remove preview version

### DIFF
--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -s https://deb.nodesource.com/setup_16.x | bash \
     && rm -rf /var/lib/apt/lists/* 
 
 # ENV variables are here to allow cache previous step and speet the build up
-ENV VEGA_VERSION=v0.72.0-preview.2
+ENV VEGA_VERSION=v0.72.0
 ENV VEGACAPSULE_VERSION=v0.70.1
 ENV NOMAD_VERSION=1.3.1
 


### PR DESCRIPTION
With the newly tagged version v0.72.0, there's no need to use preview version anymore