### PR TITLE
chore: update fe runner to 0.73.0

### DIFF
--- a/github-runner/Dockerfile
+++ b/github-runner/Dockerfile
@@ -29,8 +29,8 @@ RUN curl -s https://deb.nodesource.com/setup_16.x | bash \
     && rm -rf /var/lib/apt/lists/*
 
 # ENV variables are here to allow cache previous step and speet the build up
-ENV VEGA_VERSION=v0.72.14
-ENV VEGACAPSULE_VERSION=v0.72.0
+ENV VEGA_VERSION=v0.73.0-preview.3
+ENV VEGACAPSULE_VERSION=v0.73.0
 ENV NOMAD_VERSION=1.3.1
 
 # Install vegacapsule

--- a/github-runner/version.json
+++ b/github-runner/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "v2.301.1-ubuntu-22.04-vega-v0.72.14-1",
+    "version": "v2.301.1-ubuntu-22.04-vega-v0.73.0-1",
     "name": "vegaprotocol/github-runner"
 }
 


### PR DESCRIPTION
Update FE test runners to latest core and vegacapsule release. 