### PR TITLE
feat: log all queries to postgresql

### DIFF
--- a/timescaledb/Dockerfile
+++ b/timescaledb/Dockerfile
@@ -23,4 +23,7 @@ RUN timescaledb-tune \
 
 RUN set -euo; \
     sed -i 's/^restart_after_crash.*//' /var/lib/postgresql/data/postgresql.conf \
-        && echo "restart_after_crash=no" >> /var/lib/postgresql/data/postgresql.conf;
+        && echo "restart_after_crash=no" >> /var/lib/postgresql/data/postgresql.conf \
+    && sed -i 's/^log_statement.*//' /var/lib/postgresql/data/postgresql.conf \
+        && echo "log_statement='all'" >> /var/lib/postgresql/data/postgresql.conf \
+    ;

--- a/timescaledb/version.json
+++ b/timescaledb/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.8.0-pg14-v0.0.1",
+    "version": "2.8.0-pg14-v0.0.2",
     "name": "vegaprotocol/vegacapsule-timescaledb"
 }


### PR DESCRIPTION

# Testing

## Client session

```sh
vega=# select view_name as table_name
from timescaledb_information.continuous_aggregates WHERE hypertable_schema='public'
union all
select hypertable_name
from timescaledb_information.hypertables where hypertable_schema='public';
 table_name 
------------
(0 rows)

vega=# select view_name as table_name
from timescaledb_information.continuous_aggregates WHERE hypertable_schema='public'
union all
select hypertable_name
from timescaledb_information.hypertables where hypertable_schema='public';
 table_name 
------------
(0 rows)

vega=# SELECT something from unknonw;
ERROR:  relation "unknonw" does not exist
LINE 1: SELECT something from unknonw;
                              ^
vega=# 
```

## PostgreSQL session:

```sh
➜  timescaledb git:(log-all-queries) ✗ docker run -p 5433:5432 vegaprotocol/vegacapsule-timescaledb:test  

PostgreSQL Database directory appears to contain a database; Skipping initialization

2024-01-15 09:34:40.990 UTC [1] LOG:  starting PostgreSQL 14.5 on x86_64-pc-linux-musl, compiled by gcc (Alpine 11.2.1_git20220219) 11.2.1 20220219, 64-bit
2024-01-15 09:34:40.990 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2024-01-15 09:34:40.990 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2024-01-15 09:34:41.021 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2024-01-15 09:34:41.055 UTC [21] LOG:  database system was shut down at 2024-01-15 09:31:13 UTC
2024-01-15 09:34:41.109 UTC [1] LOG:  database system is ready to accept connections
2024-01-15 09:34:41.111 UTC [27] LOG:  TimescaleDB background worker launcher connected to shared catalogs
2024-01-15 09:39:12.048 UTC [253] FATAL:  database "data_node_db" does not exist
2024-01-15 09:39:19.929 UTC [258] LOG:  statement: select view_name as table_name
        from timescaledb_information.continuous_aggregates WHERE hypertable_schema='public'
        union all
        select hypertable_name
        from timescaledb_information.hypertables where hypertable_schema='public';
2024-01-15 09:39:26.069 UTC [258] LOG:  statement: select view_name as table_name
        from timescaledb_information.continuous_aggregates WHERE hypertable_schema='public'
        union all
        select hypertable_name
        from timescaledb_information.hypertables where hypertable_schema='public';
2024-01-15 09:39:39.720 UTC [258] LOG:  statement: SELECT something from unknonw;
2024-01-15 09:39:39.720 UTC [258] ERROR:  relation "unknonw" does not exist at character 23
2024-01-15 09:39:39.720 UTC [258] STATEMENT:  SELECT something from unknown;
```


