### PR TITLE
chore: use official truffle image as bas image

### DIFF
--- a/smartcontracts-base/Dockerfile
+++ b/smartcontracts-base/Dockerfile
@@ -1,7 +1,7 @@
 FROM ethereum/solc:0.8.8 AS solc088
 FROM ethereum/solc:0.8.1 AS solc081
 
-FROM node:20-alpine AS builder
+FROM node:20.3-alpine AS builder
 RUN mkdir /app
 WORKDIR /app
 ENV PATH="$PATH:/app/node_modules/.bin"
@@ -15,12 +15,10 @@ RUN npm install
 
 # # #
 
-FROM node:20-alpine
+FROM trufflesuite/ganache:v7.9.2
 LABEL org.opencontainers.image.source https://github.com/vegaprotocol/devops-infra
-RUN mkdir /app
-WORKDIR /app
-ENV PATH="$PATH:/app/node_modules/.bin"
-RUN apk add --no-cache bash jq openssl gcompat
+WORKDIR /app2
+ENV PATH="$PATH:/app2/node_modules/.bin"
 
 COPY --from=solc088 /usr/bin/solc /usr/bin/solc-v0.8.8
 COPY --from=solc081 /usr/bin/solc /usr/bin/solc-v0.8.1

--- a/smartcontracts-base/package.json
+++ b/smartcontracts-base/package.json
@@ -14,7 +14,6 @@
     "ethereumjs-util": "^7.0.9",
     "express": "^4.17.1",
     "fs-extra": "^10.0.0",
-    "ganache": "7.7.0",
     "ethers": "^6.6.5",
     "grpc-web": "^1.2.1",
     "keccak": "^3.0.1",

--- a/smartcontracts-base/version.json
+++ b/smartcontracts-base/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "v1.3.0",
+    "version": "v1.4.0",
     "name": "vegaprotocol/smartcontracts-base"
 }


### PR DESCRIPTION
Switch to using the offical truffle image as the base image. 

This seems to work on my Mac with ganache as version `v7.9.2`, and the problem test from before `test_modify_erc20_asset` works locally.