### PR TITLE
chore: include multisig fix for when 6 signers are on the contract

### DIFF
--- a/smartcontracts-base/contracts-solc-0.8.8/contracts/MultisigControlV2.sol
+++ b/smartcontracts-base/contracts-solc-0.8.8/contracts/MultisigControlV2.sol
@@ -109,7 +109,6 @@ contract MultisigControlV2 is IMultisigControl {
 
         uint256 size = 0;
         address[] memory signers_temp = new address[](signatures.length / 65);
-        uint256 min_signer_threshold = uint256(signer_count) * threshold;
 
         bytes32 message_hash = keccak256(abi.encodePacked(bytes1(0x19), block.chainid, abi.encode(message, msg.sender)));
         uint256 offset;
@@ -151,12 +150,12 @@ contract MultisigControlV2 is IMultisigControl {
                 size++;
             }
 
-            if (size * 1000 > min_signer_threshold) {
+            if ((size * 1000) / uint256(signer_count) > threshold) {
                 break;
             }
         }
 
-        used_nonces[nonce] = ((uint256(size) * 1000) / (uint256(signer_count))) > threshold;
+        used_nonces[nonce] = ((size * 1000) / uint256(signer_count)) > threshold;
         return used_nonces[nonce];
     }
 

--- a/smartcontracts-base/version.json
+++ b/smartcontracts-base/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "v1.5.1",
+    "version": "v1.5.2",
     "name": "vegaprotocol/smartcontracts-base"
 }


### PR DESCRIPTION
Includes fix for multisig, and bumps version of base contract to `v1.5.2`.