### PR TITLE
chore: bump ganache version and pull in latest smart contract base

### DIFF
--- a/ganache/Dockerfile
+++ b/ganache/Dockerfile
@@ -1,6 +1,6 @@
 ARG GANACHE_MNEMONIC="ozone access unlock valid olympic save include omit supply green clown session"
 
-FROM vegaprotocol/smartcontracts-base:v1.5.1
+FROM vegaprotocol/smartcontracts-base:v1.5.2
 
 ARG TARGETARCH
 ARG GANACHE_MNEMONIC

--- a/ganache/version.json
+++ b/ganache/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "v1.5.0",
+    "version": "v1.5.2",
     "name": "vegaprotocol/ganache"
 }


### PR DESCRIPTION
Bump ganache version to include latest smart-contract base which includes multisig fix.