### PR TITLE
WIP: feat: bump timescaledb to v2.15.3 and psql to 16

### DIFF
--- a/timescaledb/Dockerfile
+++ b/timescaledb/Dockerfile
@@ -1,5 +1,5 @@
 # FROM postgres:14-bullseye
-FROM timescale/timescaledb:2.8.0-pg14
+FROM timescale/timescaledb:2.15.3-pg16
 
 ENV TIMESCALEDB_TELEMETRY "off"
 ENV NO_TS_TUNE true

--- a/timescaledb/version.json
+++ b/timescaledb/version.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.8.0-pg14-v0.0.2",
+    "version": "2.15.3-pg16-v0.0.1",
     "name": "vegaprotocol/vegacapsule-timescaledb"
 }


### PR DESCRIPTION
This image has been tested with the following PR: https://github.com/vegaprotocol/system-tests/pull/3591